### PR TITLE
fix: aria2ng url

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ WeiyunHelper 是微云的辅助脚本，拥有以下功能：
 
 ### 配置 AriaNg
 
-因为目前没有直接调用 Aria2 的接口，依赖了 AriaNg 的服务。所以需要使用的用户使用 [https://aria2.me/aria-ng/](https://aria2.me/aria-ng/) 进行对应的设置后使用。
+因为目前没有直接调用 Aria2 的接口，依赖了 AriaNg 的服务。所以需要使用的用户使用 [http://ariang.mayswind.net/latest/](http://ariang.mayswind.net/latest/) 进行对应的设置后使用。
 
 如果你希望支持直接调用 Aria2 的接口也可以发起 PR 贡献你的代码 :)
 

--- a/weiyun.user.js
+++ b/weiyun.user.js
@@ -56,7 +56,7 @@
       fileName = `微云合并下载文件_${new Date().Format('yyyy-MM-dd hh:mm:ss')}.zip`;
     }
 
-    const ariaNgUrl = `http://aria2.me/aria-ng/#!/new/task?url=${btoa(downloadUrl)}&header=Cookie:${cookieName}=${cookieValue}&out=${encodeURI(fileName)}`;
+    const ariaNgUrl = `http://ariang.mayswind.net/latest/#!/new/task?url=${btoa(downloadUrl)}&header=Cookie:${cookieName}=${cookieValue}&out=${encodeURI(fileName)}`;
 
     console.log('文件名称:', fileName);
     console.log('下载地址:', downloadUrl);


### PR DESCRIPTION
It seems that [aria2.me is down](http://17ce.com/site/http/20210927_a27d37f01f9b11ecbd5ca96d8e3356b6:1.html). Change to http://ariang.mayswind.net/ which hosted by AriaNg's author.